### PR TITLE
add sync on messagesender

### DIFF
--- a/zi/src/app.rs
+++ b/zi/src/app.rs
@@ -15,7 +15,7 @@ use crate::{
     terminal::{Canvas, Event, Key, Position, Rect, Size},
 };
 
-pub trait MessageSender: Debug + Send + 'static {
+pub trait MessageSender: Debug + Send + Sync + 'static {
     fn send(&self, message: ComponentMessage);
 
     fn clone_box(&self) -> Box<dyn MessageSender>;


### PR DESCRIPTION
Add Sync to MessageSender to align it with documentation:
```
/// A context for sending messages to a component or the runtime.
///
/// It can be used in a multi-threaded environment (implements `Sync` and
/// `Send`). Additionally, it can send messages to the runtime, in particular
/// it's used to gracefully stop a running [`App`](struct.App.html).
#[derive(Debug)]
pub struct ComponentLink<ComponentT> {
     ...